### PR TITLE
Fix webhook path documentation

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -41,13 +41,13 @@ cp .env.example .env
 ## 2. Configurando o Webhook na Evolution API
 
 ### Para acesso local:
-1. URL do webhook: `http://localhost:8000/webhook`
+1. URL do webhook: `http://localhost:8000/webhook/whatsapp`
 
 ### Para acesso externo:
 1. Se estiver usando em produção, você precisa:
    - Ter um domínio configurado (exemplo: seudominio.com)
    - Configurar SSL (recomendado usar Nginx + Let's Encrypt)
-   - URL do webhook será: `https://seudominio.com/webhook`
+   - URL do webhook será: `https://seudominio.com/webhook/whatsapp`
 
 2. Se estiver testando localmente e precisar de acesso externo:
    - Use ngrok para criar um túnel:
@@ -57,13 +57,13 @@ cp .env.example .env
    ngrok http 8000
    ```
    - Copie a URL https gerada (exemplo: https://a1b2c3d4.ngrok.io)
-   - Use esta URL + /webhook na Evolution API
+   - Use esta URL + /webhook/whatsapp na Evolution API
 
 3. Na Evolution API:
    - Acesse sua instância
    - Vá em "Configurações" > "Webhooks"
    - Adicione novo webhook:
-     - URL: sua URL completa + /webhook
+     - URL: sua URL completa + /webhook/whatsapp
      - Eventos: selecione `Message_Upsert`
      - Secret: use o mesmo valor de `WEBHOOK_SECRET` do seu .env
 

--- a/EVOLUTION_SETUP_GUIDE.md
+++ b/EVOLUTION_SETUP_GUIDE.md
@@ -93,7 +93,7 @@ curl -X POST http://localhost:8888/instance/create \
   -d '{
     "instanceName": "sdr-agent",
     "qrcode": true,
-    "webhook": "http://localhost:8000/legacy/webhook"
+    "webhook": "http://localhost:8000/webhook/whatsapp"
   }'
 ```
 

--- a/PORT_CHANGES_SUMMARY.md
+++ b/PORT_CHANGES_SUMMARY.md
@@ -113,7 +113,7 @@ curl -X POST http://localhost:8888/instance/create \
   -d '{
     "instanceName": "sdr-agent",
     "qrcode": true,
-    "webhook": "http://localhost:8000/legacy/webhook"
+    "webhook": "http://localhost:8000/webhook/whatsapp"
   }'
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker-compose up -d
 
 1. Configure o webhook na Evolution API para apontar para:
 ```
-http://seu-servidor:8000/webhook
+http://seu-servidor:8000/webhook/whatsapp
 ```
 
 2. O sistema irá:
@@ -108,7 +108,7 @@ sdr-agent/
 
 ## Endpoints da API
 
-- `POST /webhook` - Recebe webhooks da Evolution API
+- `POST /webhook/whatsapp` - Recebe webhooks da Evolution API
 - `GET /health` - Healthcheck da aplicação
 - `GET /sessions/{user_id}` - Consulta dados de uma sessão
 - `DELETE /sessions/{user_id}` - Remove uma sessão

--- a/sdr-agent-architecture.md
+++ b/sdr-agent-architecture.md
@@ -188,7 +188,7 @@ from .models import WebhookData
 app = FastAPI()
 message_handler = MessageHandler()
 
-@app.post("/webhook")
+@app.post("/webhook/whatsapp")
 async def handle_webhook(data: WebhookData):
     try:
         await message_handler.process_message(data)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -71,7 +71,7 @@ class Settings(BaseSettings):
     ALLOWED_FILE_TYPES: str = "image/jpeg,image/png,image/gif,application/pdf,text/plain"
     
     # Webhook Configuration
-    WEBHOOK_PATH: str = "/webhook"
+    WEBHOOK_PATH: str = "/webhook/whatsapp"
     WEBHOOK_TIMEOUT: int = 30
     WEBHOOK_RETRY_ATTEMPTS: int = 3
     WEBHOOK_RETRY_DELAY: int = 5


### PR DESCRIPTION
## Summary
- correct webhook path in docs to `/webhook/whatsapp`
- update configuration reference
- align architecture example
- update default settings constant

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_6889560cfe108325a171bf5dd84dfe8e