### PR TITLE
Fix enum for message direction

### DIFF
--- a/src/core/db.py
+++ b/src/core/db.py
@@ -11,9 +11,9 @@ engine = create_async_engine(settings.DATABASE_URL, echo=True)
 AsyncSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 Base = declarative_base()
 
-class MessageDirection(enum.Enum):
-    INBOUND = "INBOUND"
-    OUTBOUND = "OUTBOUND"
+class MessageDirection(str, enum.Enum):
+    INBOUND = "inbound"
+    OUTBOUND = "outbound"
 
 class MessageStatus(enum.Enum):
     QUALIFIED = "qualified"


### PR DESCRIPTION
## Summary
- ensure MessageDirection enum matches PostgreSQL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6889759497b08325b6b64d17be19db51