### PR TITLE
Normalize timezone handling for message cooldown

### DIFF
--- a/api/auth/router.py
+++ b/api/auth/router.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, EmailStr
 from typing import Optional
 import jwt
 import bcrypt
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import os
 
 from src.core.supabase_db import get_supabase_db
@@ -49,12 +49,12 @@ JWT_EXPIRATION_HOURS = int(os.environ.get("JWT_EXPIRATION_HOURS", "24"))
 
 def create_access_token(user_id: str, email: str) -> str:
     """Create JWT access token"""
-    expire = datetime.utcnow() + timedelta(hours=JWT_EXPIRATION_HOURS)
+    expire = datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRATION_HOURS)
     payload = {
         "user_id": user_id,
         "email": email,
         "exp": expire,
-        "iat": datetime.utcnow()
+        "iat": datetime.now(timezone.utc)
     }
     return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
@@ -95,7 +95,7 @@ async def login(user_data: UserLogin):
         raise HTTPException(status_code=401, detail="Account is not active")
     
     # Update last login
-    await db.update_user(user['id'], {'last_login': datetime.utcnow().isoformat()})
+    await db.update_user(user['id'], {'last_login': datetime.now(timezone.utc).isoformat()})
     
     # Create access token
     access_token = create_access_token(user['id'], user['email'])

--- a/api/index.py
+++ b/api/index.py
@@ -9,7 +9,7 @@ import os
 import uuid
 import requests
 import google.generativeai as genai
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Dict, Any
 import threading
 import asyncio
@@ -38,7 +38,7 @@ def should_process_message_db(user_phone: str, client_id: str, cooldown_seconds:
             .eq('user_phone', user_phone)\
             .execute()
         
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         
         if not result.data:
             print(f"🆕 First message from {user_phone}, creating cooldown record")
@@ -52,7 +52,11 @@ def should_process_message_db(user_phone: str, client_id: str, cooldown_seconds:
             return False  # Don't process immediately, wait for cooldown
             
         record = result.data[0]
-        last_message_at = datetime.fromisoformat(record['last_message_at'].replace('Z', '+00:00'))
+        last_message_at = record['last_message_at']
+        if isinstance(last_message_at, str):
+            last_message_at = datetime.fromisoformat(last_message_at.replace('Z', '+00:00'))
+        if last_message_at.tzinfo is None:
+            last_message_at = last_message_at.replace(tzinfo=timezone.utc)
         time_diff = (now - last_message_at).total_seconds()
         
         print(f"⏱️ Last message was {time_diff:.1f}s ago (cooldown: {cooldown_seconds}s)")
@@ -78,7 +82,7 @@ def add_message_to_cooldown_db(user_phone: str, message_text: str, instance_name
             return
             
         client_id = client_config.get('id')
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         
         # Get existing cooldown record
         result = supabase.table('message_cooldown')\
@@ -222,7 +226,7 @@ def process_pending_messages_db(user_phone: str, instance_name: str, client_conf
         if current_message:
             pending_messages.append({
                 'text': current_message,
-                'timestamp': datetime.utcnow().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             })
         
         # Combine all messages into context
@@ -244,7 +248,7 @@ def process_pending_messages_db(user_phone: str, instance_name: str, client_conf
                 save_message_to_database(client_id, user_phone, response, 'outbound', user_name)
         
         # Update cooldown record - clear pending messages and set processed timestamp
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         supabase.table('message_cooldown').update({
             'pending_messages': [],
             'last_processed_at': now.isoformat()
@@ -868,7 +872,7 @@ class handler(BaseHTTPRequestHandler):
             self._send_json_response({
                 "status": "success" if success else "partial_failure",
                 "message": "Webhook reconfiguration completed",
-                "timestamp": datetime.utcnow().isoformat()
+                "timestamp": datetime.now(timezone.utc).isoformat()
             })
         elif path == 'test-ai-processing':
             # Test endpoint for AI processing
@@ -906,13 +910,13 @@ class handler(BaseHTTPRequestHandler):
                         "status": "success",
                         "ai_response": ai_response,
                         "message_sent": success,
-                        "timestamp": datetime.utcnow().isoformat()
+                        "timestamp": datetime.now(timezone.utc).isoformat()
                     })
                 else:
                     self._send_json_response({
                         "status": "error",
                         "error": "AI did not generate response",
-                        "timestamp": datetime.utcnow().isoformat()
+                        "timestamp": datetime.now(timezone.utc).isoformat()
                     }, 500)
                     
             except Exception as e:
@@ -920,7 +924,7 @@ class handler(BaseHTTPRequestHandler):
                 self._send_json_response({
                     "status": "error", 
                     "error": str(e),
-                    "timestamp": datetime.utcnow().isoformat()
+                    "timestamp": datetime.now(timezone.utc).isoformat()
                 }, 500)
         elif path.startswith('clients/') and path.endswith('/qrcode'):
             # Get QR code for specific client
@@ -1015,7 +1019,7 @@ class handler(BaseHTTPRequestHandler):
             self._send_json_response({
                 "message": "Webhook endpoint is active",
                 "path": path,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "status": "ready"
             })
         else:
@@ -1134,7 +1138,7 @@ class handler(BaseHTTPRequestHandler):
             if not supabase:
                 # Fallback to mock data if Supabase not available
                 client_id = f"client_{int(time.time())}_{hash(name) % 1000}"
-                current_time = datetime.utcnow().isoformat() + "Z"
+                current_time = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
                 
                 client_data = {
                     "id": client_id,
@@ -1174,7 +1178,7 @@ class handler(BaseHTTPRequestHandler):
             # Create client in Supabase
             try:
                 client_id = str(uuid.uuid4())
-                current_time = datetime.utcnow().isoformat()
+                current_time = datetime.now(timezone.utc).isoformat()
                 
                 client_data = {
                     "id": client_id,
@@ -1256,7 +1260,7 @@ class handler(BaseHTTPRequestHandler):
             self._send_json_response({
                 "status": "success" if success else "partial_failure",
                 "message": "Webhook reconfiguration completed",
-                "timestamp": datetime.utcnow().isoformat()
+                        "timestamp": datetime.now(timezone.utc).isoformat()
             })
         elif path == 'webhook/whatsapp' or path.startswith('webhook/whatsapp/'):
             # Webhook endpoint for Evolution API with AI processing
@@ -1270,7 +1274,7 @@ class handler(BaseHTTPRequestHandler):
                 
                 # FORCE PRINT - ESSENTIAL DEBUG INFO
                 print("=" * 80)
-                print(f"🚨 WEBHOOK RECEIVED AT {datetime.utcnow().isoformat()}")
+                print(f"🚨 WEBHOOK RECEIVED AT {datetime.now(timezone.utc).isoformat()}")
                 print(f"🚨 METHOD: {getattr(self, 'command', 'UNKNOWN')}")
                 print(f"🚨 FULL PATH: {self.path}")
                 print(f"🚨 PARSED PATH: {path}")
@@ -1420,7 +1424,7 @@ class handler(BaseHTTPRequestHandler):
                     "received": True,
                     "event": event_type,
                     "processed": True,
-                    "timestamp": datetime.utcnow().isoformat()
+                        "timestamp": datetime.now(timezone.utc).isoformat()
                 })
                 
             except Exception as e:
@@ -1430,7 +1434,7 @@ class handler(BaseHTTPRequestHandler):
                     "status": "error",
                     "error": str(e),
                     "received": True,
-                    "timestamp": datetime.utcnow().isoformat()
+                    "timestamp": datetime.now(timezone.utc).isoformat()
                 })
         else:
             self._send_json_response({

--- a/api/main_hybrid.py
+++ b/api/main_hybrid.py
@@ -9,7 +9,7 @@ from typing import Optional
 import os
 import sys
 import jwt
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # Create FastAPI app
 app = FastAPI(
@@ -102,12 +102,12 @@ JWT_EXPIRATION_HOURS = int(os.environ.get("JWT_EXPIRATION_HOURS", "24"))
 
 def create_access_token(user_id: str, email: str) -> str:
     """Create JWT access token"""
-    expire = datetime.utcnow() + timedelta(hours=JWT_EXPIRATION_HOURS)
+    expire = datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRATION_HOURS)
     payload = {
         "user_id": user_id,
         "email": email,
         "exp": expire,
-        "iat": datetime.utcnow()
+        "iat": datetime.now(timezone.utc)
     }
     return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
@@ -175,7 +175,7 @@ async def login(user_data: UserLogin):
                 if verify_password_simple(user_data.password, user_data.email):
                     # Update last login
                     supabase_client.table('users').update({
-                        'last_login': datetime.utcnow().isoformat()
+                        'last_login': datetime.now(timezone.utc).isoformat()
                     }).eq('id', user['id']).execute()
                     
                     # Create access token
@@ -256,7 +256,7 @@ async def register(user_data: UserRegister):
         last_name=user_data.last_name,
         status="active",
         plan="free",
-        created_at=datetime.utcnow().isoformat()
+        created_at=datetime.now(timezone.utc).isoformat()
     )
 
 @app.get("/auth/me", response_model=UserResponse)

--- a/api/main_simple.py
+++ b/api/main_simple.py
@@ -10,7 +10,7 @@ import os
 import sys
 import jwt
 import bcrypt
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # Add src to path for imports
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -112,12 +112,12 @@ JWT_EXPIRATION_HOURS = int(os.environ.get("JWT_EXPIRATION_HOURS", "24"))
 
 def create_access_token(user_id: str, email: str) -> str:
     """Create JWT access token"""
-    expire = datetime.utcnow() + timedelta(hours=JWT_EXPIRATION_HOURS)
+    expire = datetime.now(timezone.utc) + timedelta(hours=JWT_EXPIRATION_HOURS)
     payload = {
         "user_id": user_id,
         "email": email,
         "exp": expire,
-        "iat": datetime.utcnow()
+        "iat": datetime.now(timezone.utc)
     }
     return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
 
@@ -200,7 +200,7 @@ async def login(user_data: UserLogin):
         
         # Update last login
         client.table('users').update({
-            'last_login': datetime.utcnow().isoformat()
+            'last_login': datetime.now(timezone.utc).isoformat()
         }).eq('id', user['id']).execute()
         
         # Create access token

--- a/api/messages/router.py
+++ b/api/messages/router.py
@@ -4,7 +4,7 @@ Messages router for serverless deployment
 from fastapi import APIRouter, HTTPException, Depends, Query
 from pydantic import BaseModel
 from typing import Optional, List, Dict, Any
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 
 from src.core.supabase_db import get_supabase_db
 from api.auth.router import verify_token
@@ -78,7 +78,7 @@ async def get_messages(
     
     if date_from or date_to:
         def filter_by_date(msg):
-            msg_date = datetime.fromisoformat(msg['timestamp']).date()
+            msg_date = datetime.fromisoformat(msg['timestamp'].replace('Z', '+00:00')).date()
             if date_from and msg_date < date_from:
                 return False
             if date_to and msg_date > date_to:
@@ -148,7 +148,7 @@ async def get_message_stats(
     # Apply date filters
     if date_from or date_to:
         def filter_by_date(msg):
-            msg_date = datetime.fromisoformat(msg['timestamp']).date()
+            msg_date = datetime.fromisoformat(msg['timestamp'].replace('Z', '+00:00')).date()
             if date_from and msg_date < date_from:
                 return False
             if date_to and msg_date > date_to:
@@ -164,10 +164,10 @@ async def get_message_stats(
     qualified_leads = len([msg for msg in all_messages if msg.get('status') == 'qualified'])
     
     # Count active conversations (unique user_ids with recent messages)
-    recent_cutoff = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    recent_cutoff = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
     recent_users = set()
     for msg in all_messages:
-        msg_date = datetime.fromisoformat(msg['timestamp'])
+        msg_date = datetime.fromisoformat(msg['timestamp'].replace('Z', '+00:00'))
         if msg_date >= recent_cutoff:
             recent_users.add(msg['user_id'])
     

--- a/scripts/export_current_schema.py
+++ b/scripts/export_current_schema.py
@@ -5,7 +5,7 @@ Script to export current PostgreSQL schema and data for migration to Supabase
 import asyncio
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from sqlalchemy import text
 from src.core.db import engine, AsyncSessionLocal
 from src.core.db import User, Client, Message, Playbook, AgentConfig
@@ -15,7 +15,7 @@ async def export_schema_info():
     print("🔍 Exporting current PostgreSQL schema information...")
     
     schema_info = {
-        "export_date": datetime.utcnow().isoformat(),
+        "export_date": datetime.now(timezone.utc).isoformat(),
         "tables": {},
         "indexes": {},
         "constraints": {}
@@ -109,7 +109,7 @@ async def export_sample_data():
     print("📊 Exporting sample data...")
     
     sample_data = {
-        "export_date": datetime.utcnow().isoformat(),
+        "export_date": datetime.now(timezone.utc).isoformat(),
         "users": [],
         "clients": [],
         "messages": [],

--- a/src/api/auth_routes.py
+++ b/src/api/auth_routes.py
@@ -3,7 +3,7 @@ from fastapi.security import HTTPBearer
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from typing import List
-from datetime import datetime
+from datetime import datetime, timezone
 
 from src.core.db import get_db, User, Client, AgentConfig, UserStatus
 from src.core.auth import auth_service, get_current_active_user, create_user_token
@@ -109,7 +109,7 @@ async def login_user(
         )
     
     # Atualiza último login
-    user.last_login = datetime.utcnow()
+    user.last_login = datetime.now(timezone.utc)
     await db.commit()
     
     token_data = create_user_token(user)

--- a/src/core/auth.py
+++ b/src/core/auth.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Any
 import jwt
 from fastapi import HTTPException, status, Depends
@@ -37,9 +37,9 @@ class AuthService:
         to_encode = data.copy()
         
         if expires_delta:
-            expire = datetime.utcnow() + expires_delta
+            expire = datetime.now(timezone.utc) + expires_delta
         else:
-            expire = datetime.utcnow() + timedelta(hours=self.access_token_expire_hours)
+            expire = datetime.now(timezone.utc) + timedelta(hours=self.access_token_expire_hours)
         
         to_encode.update({"exp": expire})
         encoded_jwt = jwt.encode(to_encode, self.secret_key, algorithm=self.algorithm)
@@ -208,7 +208,7 @@ async def get_current_user(
         )
     
     # Atualiza último login
-    user.last_login = datetime.utcnow()
+    user.last_login = datetime.now(timezone.utc)
     await db.commit()
     
     return user

--- a/src/core/session.py
+++ b/src/core/session.py
@@ -1,5 +1,5 @@
-from typing import Optional, List
-from datetime import datetime
+from typing import Optional, List, Any
+from datetime import datetime, timezone
 import json
 import redis
 import uuid
@@ -35,6 +35,15 @@ class SessionManager:
         else:
             # Fallback to old format for backward compatibility
             return f"session:{user_id}"
+
+    def _normalize_timestamp(self, ts: Any) -> datetime:
+        if isinstance(ts, str):
+            dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+        else:
+            dt = ts
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
     
     async def _get_client_settings(self, client_id: str) -> Optional[ClientSettings]:
         """Load client settings from database"""
@@ -113,7 +122,7 @@ class SessionManager:
                 return SessionContext(
                     user_id=data['user_id'],
                     messages=messages,
-                    last_interaction=datetime.fromisoformat(data['last_interaction']),
+                    last_interaction=self._normalize_timestamp(data['last_interaction']),
                     metadata=data.get('metadata')
                 )
             else:

--- a/src/core/session_manager.py
+++ b/src/core/session_manager.py
@@ -15,6 +15,16 @@ from src.config.settings import settings
 
 logger = logging.getLogger(__name__)
 
+
+def normalize_timestamp(ts: Any) -> datetime:
+    if isinstance(ts, str):
+        dt = datetime.fromisoformat(ts.replace('Z', '+00:00'))
+    else:
+        dt = ts
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
 class CloudSessionManager:
     """
     Cloud-native session manager using Supabase + Upstash Redis
@@ -50,7 +60,7 @@ class CloudSessionManager:
                 return SessionContext(
                     user_id=user_id,
                     messages=messages,
-                    last_interaction=datetime.fromisoformat(session_data['last_interaction']),
+                    last_interaction=normalize_timestamp(session_data['last_interaction']),
                     metadata=session_data.get('metadata', {})
                 )
             
@@ -68,7 +78,7 @@ class CloudSessionManager:
                     user_name=db_msg.get('user_name', ''),
                     message_direction=db_msg['message_direction'],
                     content=db_msg['content'],
-                    timestamp=datetime.fromisoformat(db_msg['timestamp']) if isinstance(db_msg['timestamp'], str) else db_msg['timestamp'],
+                    timestamp=normalize_timestamp(db_msg['timestamp']),
                     metadata=db_msg.get('message_metadata', {})
                 ))
             
@@ -136,7 +146,7 @@ class CloudSessionManager:
                     user_name=db_msg.get('user_name', ''),
                     message_direction=db_msg['message_direction'],
                     content=db_msg['content'],
-                    timestamp=datetime.fromisoformat(db_msg['timestamp']) if isinstance(db_msg['timestamp'], str) else db_msg['timestamp'],
+                    timestamp=normalize_timestamp(db_msg['timestamp']),
                     metadata=db_msg.get('message_metadata', {})
                 ))
             

--- a/src/core/upstash_redis.py
+++ b/src/core/upstash_redis.py
@@ -6,7 +6,7 @@ import json
 import redis
 from typing import Optional, Dict, Any
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +97,7 @@ class SessionManager:
     async def store_session(self, client_id: str, user_id: str, session_data: Dict[str, Any]) -> bool:
         """Store user session data"""
         key = self._get_session_key(client_id, user_id)
-        session_data['last_activity'] = datetime.utcnow().isoformat()
+        session_data['last_activity'] = datetime.now(timezone.utc).isoformat()
         return await self.redis.set_with_expiry(key, session_data, self.default_expiry)
     
     async def get_session(self, client_id: str, user_id: str) -> Optional[Dict[str, Any]]:
@@ -110,7 +110,7 @@ class SessionManager:
         session = await self.get_session(client_id, user_id)
         if session:
             session.update(updates)
-            session['last_activity'] = datetime.utcnow().isoformat()
+            session['last_activity'] = datetime.now(timezone.utc).isoformat()
             return await self.store_session(client_id, user_id, session)
         return False
     
@@ -135,7 +135,7 @@ class SessionManager:
         
         conversation_data = {
             'messages': messages,
-            'updated_at': datetime.utcnow().isoformat()
+            'updated_at': datetime.now(timezone.utc).isoformat()
         }
         
         return await self.redis.set_with_expiry(key, conversation_data, self.default_expiry * 24)  # 24 hours for conversation

--- a/supabase/migrations/20250808000002_fix_timezone_message_cooldown.sql
+++ b/supabase/migrations/20250808000002_fix_timezone_message_cooldown.sql
@@ -1,0 +1,4 @@
+-- Ensure message_cooldown timestamp columns are stored with timezone
+ALTER TABLE message_cooldown
+  ALTER COLUMN last_message_at TYPE timestamptz USING last_message_at AT TIME ZONE 'UTC',
+  ALTER COLUMN last_processed_at TYPE timestamptz USING last_processed_at AT TIME ZONE 'UTC';

--- a/test_full_system.py
+++ b/test_full_system.py
@@ -10,7 +10,7 @@ Teste completo do sistema SDR Agent
 import requests
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Configuração do teste
 BASE_URL = "https://sdr-agent-five.vercel.app"
@@ -53,7 +53,7 @@ def test_webhook_message():
             "source": "test"
         },
         "destination": f"{BASE_URL}/api/webhook/whatsapp/{INSTANCE}",
-        "date_time": datetime.utcnow().isoformat() + "Z",
+        "date_time": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "sender": f"{TEST_PHONE}@s.whatsapp.net",
         "server_url": "http://localhost:8080",
         "apikey": "test-api-key"

--- a/test_message_insert.py
+++ b/test_message_insert.py
@@ -2,7 +2,7 @@
 """Test direct message insertion to validate the fix"""
 
 from supabase import create_client
-from datetime import datetime
+from datetime import datetime, timezone
 
 def test_direct_insert():
     """Test inserting a message directly to verify schema compatibility"""
@@ -65,7 +65,7 @@ def test_old_structure():
             "user_id": "5561936180578@s.whatsapp.net",
             "message_direction": "inbound",
             "content": "Test message old structure",
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "status": "none",
             "lead_score": 0
         }


### PR DESCRIPTION
## Summary
- ensure UTC-aware datetimes across API and services
- normalize Supabase timestamp parsing and session handling
- add migration to enforce timestamptz in message_cooldown

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings'; ValueError: Missing required Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_b_6894b67f8a948325abe6a9f9771f893b